### PR TITLE
Update input.js to have access to ref

### DIFF
--- a/form-handle-with-formik/src/components/Input.js
+++ b/form-handle-with-formik/src/components/Input.js
@@ -16,14 +16,15 @@ class Input extends PureComponent {
   };
 
   render() {
-    const { label, error, ...rest } = this.props;
+    const { forwardedRef, error, label, ...rest } = this.props;
     return (
       <View style={styles.root}>
         <FormLabel>{label}</FormLabel>
         <FormInput
-          onChangeText={this._handleChange}
           onBlur={this._handleTouch}
+          onChangeText={this._handleChange}
           placeholder={label}
+          ref={forwardedRef}
           {...rest}
         />
         {error && <FormValidationMessage>{error}</FormValidationMessage>}
@@ -39,4 +40,21 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Input;
+export default React.forwardRef((props, ref) => <Input forwardedRef={ref} {...props} />)
+
+/**
+Just for demistration purposes I've included a simplified version of the above using the ref fowarding
+*/
+const SimplifiedInput = React.forwardRef(({ error, label, name, onChange, onTouch, ...rest }, ref) =>
+  <View style={styles.root}>
+    <FormLabel>{label}</FormLabel>
+    <FormInput
+      onBlur={() => onTouch(name)}
+      onChangeText={value => onChange(name, value)}
+      placeholder={label}
+      ref={ref}
+      {...rest}
+    />
+    {error && <FormValidationMessage>{error}</FormValidationMessage>}
+  </View>
+)


### PR DESCRIPTION
Since this is for react native and native allows us to do custom things with the keyboards easily using props like onSubmitEditing or using a custom keyboard I figured I'd share an easy way to keep access to the ref since your video is really helpful to get started.  It also may be beyond the scope of what you were trying to show but you might be able to throw it in one of your future videos. 

Note this is only available in react 16.3+ and you must set the ref prop on the actual input (<Input ref={n=>this.email=n}/>).